### PR TITLE
create new method: load_env_file

### DIFF
--- a/defaultenv.py
+++ b/defaultenv.py
@@ -34,12 +34,17 @@ def read_env_file(fname=__fname__):
         __env_timestamp__ = os.path.getmtime(fname)
 
 
-def env(key, default=None):
+def load_env_file():
     try:
         if os.path.getmtime(__fname__) > __env_timestamp__:
             read_env_file()
     except:
         pass
+
+
+def env(key, default=None):
+    load_env_file()
+
     key = os.environ[key] if key in os.environ else None
     if not key:
         return default(key) if callable(default) else default


### PR DESCRIPTION
Problem:

```python
>>> from defaultenv import env; import os; 
>>> print(os.environ['MONGODB_DB'])
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/3.6/lib/python3.6/os.py", line 669, in __getitem__
    raise KeyError(key) from None
KeyError: 'MONGODB_DB'
```

Fix:
```python
>>> from defaultenv import load_env_file; load_env_file(); import os; 
>>> print(os.environ['MONGODB_DB'])
test_db
```

and there is no problem of priorities:
problem:
```python
>>> from defaultenv import env;
>>> print(env('MONGODB_DB'))
test_db
>>> os.environ['MONGODB_DB'] = 'prod_db'
>>> print(env('MONGODB_DB'))  #  Not use env, and use os.environ
test_db
```

fix: 
```python
>>> from defaultenv import load_env_file; load_env_file(); import os; 
>>> print(os.environ('MONGODB_DB'))
test_db
>>> os.environ['MONGODB_DB'] = 'prod_db'
>>> print(os.environ('MONGODB_DB'))
prod_db
```


